### PR TITLE
fix: import missing BeatLoader in  LinkPage.jsx

### DIFF
--- a/src/pages/LinkPage.jsx
+++ b/src/pages/LinkPage.jsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import DeviceStats from "@/components/DeviceStats";
 import LocationStats from "@/components/LocationStats";
+import { BeatLoader } from "react-spinners";
 
 const LinkPage = () => {
   const { user } = UrlState();


### PR DESCRIPTION
This PR fixes a missing import of `BeatLoader` in the LinkPage.jsx file. The component was being used without being imported, which could lead to runtime errors or unexpected behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading spinner to the delete button to indicate progress during URL deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->